### PR TITLE
fix: Feature type member

### DIFF
--- a/KmlToGeoJson/KmlToGeoJson/Model/Feature.cs
+++ b/KmlToGeoJson/KmlToGeoJson/Model/Feature.cs
@@ -8,7 +8,7 @@ namespace KmlToGeoJson.Model
 {
     public class Feature
     {
-        [JsonPropertyName("feature")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; } = "Feature";
 
         [JsonPropertyName("id")]


### PR DESCRIPTION
According [to the spec](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2), the Feature object must have a `type` member with the value `Feature`.