### PR TITLE
Resolve ExtendedData not being written into properties

### DIFF
--- a/KmlToGeoJson/KmlToGeoJson/KmlToGeoJsonConverter.cs
+++ b/KmlToGeoJson/KmlToGeoJson/KmlToGeoJsonConverter.cs
@@ -383,9 +383,11 @@ namespace KmlToGeoJson
             // Inline Styles:
             var iconStyle = root.Element(Kml + "Style")?.Element(Kml + "IconStyle");
             var labelStyle = root.Element(Kml + "Style")?.Element(Kml + "LabelStyle");
-            var extendedData = root.Element(Kml + "Style")?.Element(Kml + "ExtendedData");
             var lineStyle = root.Element(Kml + "Style")?.Element(Kml + "LineStyle");
             var polyStyle = root.Element(Kml + "Style")?.Element(Kml + "PolyStyle");
+
+            // Extended Data
+            var extendedData = root.Element(Kml + "ExtendedData");
 
             var visibility = root.Element(Kml + "visibility");
 


### PR DESCRIPTION
### **Fix: Ensure `ExtendedData` is Written into `properties`**  

#### **Summary**  
This PR resolves an issue where `ExtendedData` from KML files was not written into the `properties` field of the resulting GeoJSON.  

#### **Example Output (After Fix)**  
```json
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [
      -122,
      37.002
    ]
  },
  "properties": {
    "name": "Easy trail",
    "styleUrl": "#trailhead-balloon-template",
    "styleHash": "3CC8856DAF99DD174384F426D07C60EE",
    "TrailHeadName": "Pi in the sky", // written successfully
    "TrailLength": "3.14159", // written successfully
    "ElevationGain": "10" // written successfully
  }
}
```

#### **Testing**  
- Verified output using `simpledata.kml`.  
- Confirmed that previously missing `ExtendedData` properties are now included.  